### PR TITLE
마크다운 컴포넌트 분리 및 UI 정리

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,10 @@
   @apply my-2;
 }
 
+.markdown code::before, .markdown code::after {
+  display: none;
+}
+
 #background {
   @apply fixed h-full w-full bg-slate-50 lg:bg-gradient-to-r lg:from-sky-400 lg:to-indigo-400;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -76,6 +76,14 @@
   }
 }
 
+.markdown {
+  @apply prose;
+}
+
+.markdown * {
+  @apply my-2;
+}
+
 #background {
   @apply fixed h-full w-full bg-slate-50 lg:bg-gradient-to-r lg:from-sky-400 lg:to-indigo-400;
 }

--- a/app/quizzes/[id]/choice-form.tsx
+++ b/app/quizzes/[id]/choice-form.tsx
@@ -5,6 +5,7 @@ import { useGetChoicesOfQuiz, useSubmitQuiz } from '@/services/quiz/hooks';
 import { useRouter } from 'next/navigation';
 import Button from '@/components/common/buttons/button';
 import LoadingSpinner from '@/components/common/loading-spinner/loading-spinner';
+import MarkDown from '@/components/ui/markdown';
 
 export default function ChoiceForm({ quizId }: { quizId: number }) {
   const [errorMessage, setErrorMessage] = useState('');
@@ -41,17 +42,22 @@ export default function ChoiceForm({ quizId }: { quizId: number }) {
 
   return (
     <form onSubmit={handleSubmit}>
-      {choices?.map((choice) => (
-        <label className="flex gap-2" key={choice.id} htmlFor={`${choice.id}`}>
-          <input
-            id={`${choice.id}`}
-            value={`${choice.id}`}
-            type="radio"
-            name="choice"
-            onChange={() => setErrorMessage('')}
-          />
-          <p className="my-1.5">{choice.description}</p>
-        </label>
+      {choices?.map((choice, idx) => (
+        <div className="flex flex-col gap-4" key={choice.id}>
+          <label className="mt-4 flex gap-2" htmlFor={`${choice.id}`}>
+            <input
+              id={`${choice.id}`}
+              value={`${choice.id}`}
+              type="radio"
+              name="choice"
+              onChange={() => setErrorMessage('')}
+            />
+            <h2 className="grow font-bold">{idx + 1}번 선택지</h2>
+          </label>
+          <MarkDown wrapLine={true} wrapLongLines={true}>
+            {choice.description}
+          </MarkDown>
+        </div>
       ))}
       {errorMessage && <p className="my-2 text-red-500">{errorMessage}</p>}
       <Button

--- a/app/quizzes/[id]/page.tsx
+++ b/app/quizzes/[id]/page.tsx
@@ -3,10 +3,8 @@ import {
   QueryClient,
   dehydrate,
 } from '@tanstack/react-query';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/cjs/styles/prism';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import MarkDown from '@/components/ui/markdown';
 import Link from 'next/link';
 import ChoiceForm from './choice-form';
 import quizOptions from '@/services/quiz/options';
@@ -32,32 +30,7 @@ export default async function Page({ params }: { params: { id: string } }) {
 
       <section className="mb-10">
         <h2 className="text-2xl font-bold">문제</h2>
-        <Markdown
-          className="prose"
-          remarkPlugins={[remarkGfm]}
-          components={{
-            code({ className, children, ...rest }) {
-              const match = /language-(\w+)/.exec(className || '');
-              return match ? (
-                <SyntaxHighlighter
-                  {...rest}
-                  PreTag="div"
-                  language={match[1]}
-                  style={dracula}
-                  ref={null}
-                >
-                  {String(children).replace(/\n$/, '')}
-                </SyntaxHighlighter>
-              ) : (
-                <code {...rest} className={className}>
-                  {children}
-                </code>
-              );
-            },
-          }}
-        >
-          {quiz?.description}
-        </Markdown>
+        <MarkDown style={dracula}>{quiz?.description}</MarkDown>
       </section>
 
       <section className="mb-10">

--- a/app/quizzes/[id]/page.tsx
+++ b/app/quizzes/[id]/page.tsx
@@ -21,21 +21,21 @@ export default async function Page({ params }: { params: { id: string } }) {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <section className="mb-10">
-        <h2 className="text-2xl font-bold">출제자</h2>
-        {/* TODO: 추후 상세 유저 페이지 라우팅 경로로 변경하기 */}
-        <Link className="underline" href={`/users/${quiz?.users?.id}`}>
-          {quiz?.users?.name}
-        </Link>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">
+            {quiz?.id} {quiz?.title}
+          </h1>
+          <p>
+            By{' '}
+            <Link className="underline" href={`/users/${quiz?.users?.id}`}>
+              {/* TODO: 추후 상세 유저 페이지 라우팅 경로로 변경하기 */}
+              {quiz?.users?.name}
+            </Link>
+          </p>
+        </div>
       </section>
-
-      <section className="mb-10">
-        <h2 className="text-2xl font-bold">문제</h2>
-        <MarkDown style={dracula}>{quiz?.description ?? ''}</MarkDown>
-      </section>
-
-      <section className="mb-10">
-        <ChoiceForm quizId={quizId} />
-      </section>
+      <MarkDown style={dracula}>{quiz?.description ?? ''}</MarkDown>
+      <ChoiceForm quizId={quizId} />
     </HydrationBoundary>
   );
 }

--- a/app/quizzes/[id]/page.tsx
+++ b/app/quizzes/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function Page({ params }: { params: { id: string } }) {
 
       <section className="mb-10">
         <h2 className="text-2xl font-bold">문제</h2>
-        <MarkDown style={dracula}>{quiz?.description}</MarkDown>
+        <MarkDown style={dracula}>{quiz?.description ?? ''}</MarkDown>
       </section>
 
       <section className="mb-10">

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -37,7 +37,7 @@ export default function MarkDown({
           ) : (
             <code
               {...rest}
-              className={cn('bg-gray-300 p-1 rounded-md', className)}
+              className={cn('bg-gray-300 py-1 px-1.5 rounded-md', className)}
               style={{ color: '#FF5262' }}
             >
               {children}

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/libs/utils';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { dracula } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import remarkGfm from 'remark-gfm';
+
+interface MarkDownProps
+  extends Pick<
+    React.ComponentPropsWithoutRef<typeof ReactMarkdown>,
+    'className' | 'children'
+  > {
+  style: {
+    [key: string]: React.CSSProperties;
+  };
+}
+
+export default function MarkDown({
+  className,
+  style = dracula,
+  children,
+  ...props
+}: MarkDownProps) {
+  return (
+    <ReactMarkdown
+      className={cn('prose', className)}
+      remarkPlugins={[remarkGfm]}
+      components={{
+        code({ className, children, ...rest }) {
+          const match = /language-(\w+)/.exec(className || '');
+          return match ? (
+            <SyntaxHighlighter
+              {...rest}
+              PreTag="div"
+              language={match[1]}
+              style={style}
+              ref={null}
+            >
+              {String(children).replace(/\n$/, '')}
+            </SyntaxHighlighter>
+          ) : (
+            <code {...rest} className={className}>
+              {children}
+            </code>
+          );
+        },
+      }}
+      {...props}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -17,7 +17,7 @@ export default function MarkDown({
 }: MarkdownProps) {
   return (
     <ReactMarkdown
-      className={cn('prose', className)}
+      className={cn('markdown', className)}
       remarkPlugins={[remarkGfm]}
       components={{
         code({ className, children, ...rest }) {

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -5,49 +5,47 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import remarkGfm from 'remark-gfm';
 
-interface MarkDownProps
-  extends Pick<
-    React.ComponentPropsWithoutRef<typeof ReactMarkdown>,
-    'className' | 'children'
-  > {
-  style: {
-    [key: string]: React.CSSProperties;
-  };
+interface MarkdownProps extends React.ComponentProps<typeof SyntaxHighlighter> {
+  className?: string;
 }
 
 export default function MarkDown({
+  children,
   className,
   style = dracula,
-  children,
   ...props
-}: MarkDownProps) {
+}: MarkdownProps) {
   return (
     <ReactMarkdown
       className={cn('prose', className)}
       remarkPlugins={[remarkGfm]}
       components={{
         code({ className, children, ...rest }) {
-          const match = /language-(\w+)/.exec(className || '');
-          return match ? (
+          const language = className?.replace('language-', '');
+
+          return language ? (
             <SyntaxHighlighter
               {...rest}
-              PreTag="div"
-              language={match[1]}
+              customStyle={{ padding: '0', overflow: 'hidden' }}
+              language={language}
               style={style}
               ref={null}
+              {...props}
             >
               {String(children).replace(/\n$/, '')}
             </SyntaxHighlighter>
           ) : (
-            <code {...rest} className={className}>
+            <code
+              {...rest}
+              className={cn('bg-gray-300 p-1 rounded-md', className)}
+            >
               {children}
             </code>
           );
         },
       }}
-      {...props}
     >
-      {children}
+      {String(children)}
     </ReactMarkdown>
   );
 }

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -38,6 +38,7 @@ export default function MarkDown({
             <code
               {...rest}
               className={cn('bg-gray-300 p-1 rounded-md', className)}
+              style={{ color: '#FF5262' }}
             >
               {children}
             </code>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- #33 

## ✅ 작업 사항
- Markdown 컴포넌트 분리
- 마크다운 내 요소의 margin 등 스타일 조정
- 선택지에 마크다운 적용
- UI에 퀴즈 제목도 표현


## 👩‍💻 공유 포인트 및 논의 사항
### 1번 문제
![image](https://github.com/grow-playground/type-time/assets/50488780/b843ea71-b4b5-4691-856f-0485ed76cf0b)

### 2번 문제
![image](https://github.com/grow-playground/type-time/assets/50488780/1ad8514c-7641-4ec7-aa16-f43c379e520c)

### 6번 문제
![image](https://github.com/grow-playground/type-time/assets/50488780/b78b8d00-b61c-429c-b4ee-f83da7338242)

