### PR TITLE
퀴즈 출제 기능

### DIFF
--- a/app/quizzes/writer/_components/writer-form.tsx
+++ b/app/quizzes/writer/_components/writer-form.tsx
@@ -9,21 +9,31 @@ import Hints from './hints';
 import Choices from './choices';
 import TitleAndDifficulty from './title-and-difficulty';
 import { Inputs, useWriterForm, formLiteral } from './writer-form-schema';
+import { useCreateQuiz } from '@/services/quiz/hooks';
+import LoadingSpinner from '@/components/common/loading-spinner/loading-spinner';
+import { useRouter } from 'next/navigation';
 
 export default function WriterForm() {
   const form = useWriterForm();
+  const router = useRouter();
+
+  const { mutate: createQuiz, isPending, isSuccess } = useCreateQuiz();
 
   const {
     register,
     handleSubmit,
     watch,
     setValue,
+    setError,
     trigger,
     formState: { errors },
   } = form;
 
   const onSubmit: SubmitHandler<Inputs> = (data) => {
-    console.log(data);
+    createQuiz(data, {
+      onSuccess: (quiz) => router.push(`/quizzes/${quiz.id}`),
+      onError: (error) => setError('root', { message: error.message }),
+    });
   };
 
   const onError: SubmitErrorHandler<Inputs> = (errors) => {
@@ -125,8 +135,21 @@ export default function WriterForm() {
         )}
       </section>
 
-      <Button className="w-full" type="submit">
-        작성 완료
+      {errors.root && (
+        <p className="mt-2 text-sm text-red-500">{errors.root.message}</p>
+      )}
+
+      <Button
+        className="mt-4 flex h-10 w-full items-center justify-center disabled:bg-blue-primary"
+        disabled={isPending || isSuccess}
+      >
+        {isSuccess ? (
+          '성공!'
+        ) : isPending ? (
+          <LoadingSpinner size="lg" weight="sm" />
+        ) : (
+          '퀴즈 만들기'
+        )}
       </Button>
     </form>
   );

--- a/services/quiz/api.ts
+++ b/services/quiz/api.ts
@@ -1,7 +1,7 @@
 import { QuizTableSchema } from '@/libs/models';
 import { createClient } from '@/utils/supabase/client';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Inputs } from '@/app/quizzes/writer/_components/writer-form-schema';
+import { type Inputs as QuizInputs } from '@/app/quizzes/writer/_components/writer-form-schema';
 
 const quizAPI = {
   getQuizzes: async () => {
@@ -82,7 +82,7 @@ const quizAPI = {
     return data;
   },
 
-  postQuiz: async (params: Omit<Inputs, 'hintInput'>) => {
+  postQuiz: async (params: Omit<QuizInputs, 'hintInput'>) => {
     const supabase: SupabaseClient<Database> = createClient();
 
     const {

--- a/services/quiz/api.ts
+++ b/services/quiz/api.ts
@@ -1,6 +1,7 @@
 import { QuizTableSchema } from '@/libs/models';
 import { createClient } from '@/utils/supabase/client';
 import { SupabaseClient } from '@supabase/supabase-js';
+import { Inputs } from '@/app/quizzes/writer/_components/writer-form-schema';
 
 const quizAPI = {
   getQuizzes: async () => {
@@ -79,6 +80,61 @@ const quizAPI = {
       .eq('quiz_id', quizId);
 
     return data;
+  },
+
+  postQuiz: async (params: Omit<Inputs, 'hintInput'>) => {
+    const supabase: SupabaseClient<Database> = createClient();
+
+    const {
+      title,
+      summary,
+      hints,
+      difficulty,
+      description,
+      choices,
+      answer,
+      answerDescription,
+    } = params;
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    const { data: quiz } = await supabase
+      .from('quizzes')
+      .insert({
+        title,
+        summary,
+        description,
+        difficulty,
+        user_id: session?.user.id,
+      })
+      .select()
+      .limit(1)
+      .single();
+
+    if (!quiz) {
+      throw new Error('퀴즈 생성 실패');
+    }
+
+    await Promise.all([
+      supabase.from('hints').insert(
+        hints.map((hint) => ({
+          quiz_id: quiz.id,
+          description: hint.value,
+        }))
+      ),
+      supabase.from('choices').insert(
+        choices.map((choice, idx) => ({
+          quiz_id: quiz.id,
+          description: choice.value,
+          answer: idx + 1 === answer ? true : false,
+          answer_description: idx + 1 === answer ? answerDescription : null,
+        }))
+      ),
+    ]);
+
+    return quiz;
   },
 
   postQuizSubmission: async (params: { quizId: number; choiceId: number }) => {

--- a/services/quiz/hooks.ts
+++ b/services/quiz/hooks.ts
@@ -28,3 +28,9 @@ export function useSubmitQuiz() {
     mutationFn: quizAPI.postQuizSubmission,
   });
 }
+
+export function useCreateQuiz() {
+  return useMutation({
+    mutationFn: quizAPI.postQuiz,
+  });
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #15 

## ✅ 작업 사항
- 폼 내용을 가지고 실제 DB 데이터를 생성하는 로직을 작성했어요.
  - 안정성을 위해 라우트 핸들러를 이용할까 싶었지만, 다시 핸들러에서 유효성 검사를 하는 부분이 번거로울 것 같아서 클라이언트에서 `zod` 로 검증한 데이터를 그대로 Supabase에 생성하도록 구현했어요.

`main` <- `문제-출제` <- `문제-출제-핸들러` 브랜치 순서로 순차적으로 병합할 계획입니다 😁

## 👩‍💻 공유 포인트 및 논의 사항

### 트랜잭션 관련

`quizzes`, `choices`, `hints` 테이블에 동시에 컬럼이 추가되어야 하는데, 그 와중에 하나라도 에러가 난다면 전부 롤백하는 것이 Atomicity를 지키는 안정적인 기능이라는 판단이 들었어요. 그래서 **트랜잭션**을 이용하는 게 맞다는 생각은 들었지만 Supabase에서 트랜잭션을 어떻게 사용하는 건지 잘 모르겠네용.. 😂

(트랜잭션을 활용할 수 있어야 생성 로직에 대한 테스트 코드를 작성하기에도 수월할 거라는 생각은 들었는데.. Supabase로 그 만큼의 신뢰성 있는 용도로 활용하기 보다 빠르게 프로토타이핑을 해보라는 의도로 있는 기술인 듯 싶기도 하네요.. 아니면 아직 방법을 못 찾은 걸지도.. 😂)


### 실제로 생성된 퀴즈

![image](https://github.com/grow-playground/type-time/assets/50488780/f10de689-609b-4b04-871a-b8824df101d2)
